### PR TITLE
Wrap promises and limit to 2 concurrent requests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -570,6 +570,11 @@
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
     },
+    "cdata": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/cdata/-/cdata-0.1.1.tgz",
+      "integrity": "sha512-H0gfEXypjHisCI4xkBfh6wAyzDESay6sscM5xeJMQu7zlYrq/jHzxzOfLElg/ULpkAGNomxzENi6tY6wXWNt9w=="
+    },
     "chalk": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
@@ -713,6 +718,14 @@
             "hoek": "4.2.0"
           }
         }
+      }
+    },
+    "cwait": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cwait/-/cwait-1.1.1.tgz",
+      "integrity": "sha512-VRS0E6E41fK2QDYIGsVeE6FRXoH5Vf3hGtDL/jZxh3W+KPVVoEggDem5xJveihgZrd+xmYSqGPIUi/jv5zXcxQ==",
+      "requires": {
+        "cdata": "0.1.1"
       }
     },
     "d3": {
@@ -2502,11 +2515,6 @@
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
     },
-    "jStat": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/jStat/-/jStat-1.7.1.tgz",
-      "integrity": "sha512-toueem/U5hyHM6pqe6OZOL/5P8MrY7Ss1K8Brg+TcfX+RAjDU/sbwy72fwzmLPQ5ykdBe1UEoWQHc7OSNWMUDQ=="
-    },
     "jquery": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.3.1.tgz",
@@ -2578,6 +2586,11 @@
         "json-schema": "0.2.3",
         "verror": "1.10.0"
       }
+    },
+    "jStat": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/jStat/-/jStat-1.7.1.tgz",
+      "integrity": "sha512-toueem/U5hyHM6pqe6OZOL/5P8MrY7Ss1K8Brg+TcfX+RAjDU/sbwy72fwzmLPQ5ykdBe1UEoWQHc7OSNWMUDQ=="
     },
     "kareem": {
       "version": "1.5.0",
@@ -3138,16 +3151,6 @@
         "lodash": "4.17.5"
       }
     },
-    "require-uncached": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
-      "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
-      "dev": true,
-      "requires": {
-        "caller-path": "0.1.0",
-        "resolve-from": "1.0.1"
-      }
-    },
     "require_optional": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.1.tgz",
@@ -3162,6 +3165,16 @@
           "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
           "integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c="
         }
+      }
+    },
+    "require-uncached": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
+      "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
+      "dev": true,
+      "requires": {
+        "caller-path": "0.1.0",
+        "resolve-from": "1.0.1"
       }
     },
     "resolve": {
@@ -3411,6 +3424,14 @@
       "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
       "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks="
     },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "requires": {
+        "safe-buffer": "5.1.1"
+      }
+    },
     "string-width": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
@@ -3419,14 +3440,6 @@
       "requires": {
         "is-fullwidth-code-point": "2.0.0",
         "strip-ansi": "4.0.0"
-      }
-    },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "requires": {
-        "safe-buffer": "5.1.1"
       }
     },
     "stringstream": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "dependencies": {
     "apicache": "^1.1.0",
     "body-parser": "^1.15.2",
+    "cwait": "1.1.1",
     "d3": "^4.13.0",
     "d3-collection": "^1.0.4",
     "debug": "^3.1.0",


### PR DESCRIPTION
This PR adds a package called `cwait` that lets you wrap Promises and queue them. In this case, we limit concurrent Promises (which are fetches) by 2 so as not to overload Carto.
