### PR TITLE
Switch to NYC GeoSearch

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -1,1 +1,1 @@
-MAPZEN_API_KEY=somecomplexkey
+MONGO_URI=

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ You will need the following things properly installed on your computer.
 
 - Clone this repo `https://github.com/NYCPlanning/labs-factfinder-api.git`
 - Install Dependencies `npm install`
-- Create `.env` file based on `.env-example` with your mapzen api key and mongo uri
+- Create `.env` file based on `.env-example` with your mongo uri
 - Start the server `npm run devstart`
 
 ## Architecture
@@ -25,7 +25,7 @@ The `profile` routes contain simple middleware that adds `Cache-control` headers
 ### Routes
 
 - `/search` - gets results that match a string passed in as query parameter `q`.  Returns various search result types:
-  - `mapzen` - mapzen autocomplete api results
+  - `geosearch` - autocomplete API results
   - `nta` - neighborhoods that match the input query
   - `puma` - pumas that match the input query
   - `tract` - tracts that match the input query
@@ -48,7 +48,7 @@ The `profile` routes contain simple middleware that adds `Cache-control` headers
 ## Backend services
 
 - **Carto** - Carto instance with MapPLUTO and other Zoning-related datasets
-- **mapzen search api** - Mapzen autocomplete search results
+- **NYC GeoSearch API** - Autocomplete search results
 - **mongolab** - cloud-hosted mongodb service
 
 ## Testing and checks

--- a/package-lock.json
+++ b/package-lock.json
@@ -2552,6 +2552,11 @@
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
     },
+    "jStat": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/jStat/-/jStat-1.7.1.tgz",
+      "integrity": "sha512-toueem/U5hyHM6pqe6OZOL/5P8MrY7Ss1K8Brg+TcfX+RAjDU/sbwy72fwzmLPQ5ykdBe1UEoWQHc7OSNWMUDQ=="
+    },
     "jquery": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.3.1.tgz",
@@ -2623,11 +2628,6 @@
         "json-schema": "0.2.3",
         "verror": "1.10.0"
       }
-    },
-    "jStat": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/jStat/-/jStat-1.7.1.tgz",
-      "integrity": "sha512-toueem/U5hyHM6pqe6OZOL/5P8MrY7Ss1K8Brg+TcfX+RAjDU/sbwy72fwzmLPQ5ykdBe1UEoWQHc7OSNWMUDQ=="
     },
     "kareem": {
       "version": "1.5.0",
@@ -3193,6 +3193,16 @@
         "lodash": "4.17.5"
       }
     },
+    "require-uncached": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
+      "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
+      "dev": true,
+      "requires": {
+        "caller-path": "0.1.0",
+        "resolve-from": "1.0.1"
+      }
+    },
     "require_optional": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.1.tgz",
@@ -3207,16 +3217,6 @@
           "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
           "integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c="
         }
-      }
-    },
-    "require-uncached": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
-      "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
-      "dev": true,
-      "requires": {
-        "caller-path": "0.1.0",
-        "resolve-from": "1.0.1"
       }
     },
     "resolve": {
@@ -3466,14 +3466,6 @@
       "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
       "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks="
     },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
-    },
     "string-width": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
@@ -3482,6 +3474,14 @@
       "requires": {
         "is-fullwidth-code-point": "2.0.0",
         "strip-ansi": "4.0.0"
+      }
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "requires": {
+        "safe-buffer": "5.1.1"
       }
     },
     "stringstream": {

--- a/routes/search.js
+++ b/routes/search.js
@@ -1,6 +1,6 @@
 const express = require('express');
 
-const mapzen = require('../search-helpers/mapzen');
+const geosearch = require('../search-helpers/geosearch');
 const neighborhoodTabulationArea = require('../search-helpers/neighborhood-tabulation-area');
 const puma = require('../search-helpers/puma');
 const tract = require('../search-helpers/tract');
@@ -12,7 +12,7 @@ router.get('/', (req, res) => {
   const { q } = req.query;
 
   Promise.all([
-    mapzen(q),
+    geosearch(q),
     neighborhoodTabulationArea(q),
     puma(q),
     tract(q),

--- a/search-helpers/geosearch.js
+++ b/search-helpers/geosearch.js
@@ -1,10 +1,9 @@
 const rp = require('request-promise');
 
-const mapzen = (string) => {
-  const mapzenSearchAPI =
-   `https://search.mapzen.com/v1/autocomplete?&api_key=${process.env.MAPZEN_API_KEY}&boundary.rect.min_lon=-74.292297&boundary.rect.max_lon=-73.618011&boundary.rect.min_lat=40.477248&boundary.rect.max_lat=40.958123&text=${string}`;
+const geosearch = (string) => {
+  const geoSearchAPI = `https://geosearch.planninglabs.nyc/v1/autocomplete?text=${string}`;
 
-  return rp(mapzenSearchAPI)
+  return rp(geoSearchAPI)
     .then(res => JSON.parse(res))
     .then(json => json.features.filter(feature => feature.properties.borough))
     .then(json => json.map((feature) => {
@@ -20,4 +19,4 @@ const mapzen = (string) => {
     .then(json => json.slice(0, 5)); // limit to first 5 results
 };
 
-module.exports = mapzen;
+module.exports = geosearch;


### PR DESCRIPTION
This PR removes all references to [Mapzen Search](https://mapzen.com/search/), and swaps them for [NYC GeoSearch](https://geosearch.planninglabs.nyc/). 

Closes #15. 