### PR TITLE
Create comments--calculation changes from signficance to reliability

### DIFF
--- a/query-helpers/profile-single.js
+++ b/query-helpers/profile-single.js
@@ -96,9 +96,10 @@ const buildSQL = function buildSQL(profile, geoid, compare) {
           m as comparison_m
         FROM comparison_enriched_selection
       )
-    SELECT 
+    SELECT
       *,
       -- change_percentage_point_significant --
+      -- (actually reflect reliability, issue #57) --
       CASE
         WHEN ((((change_percentage_point_m) / 1.645) / nullif(ABS(change_percentage_point), 0)) * 100) < 20 THEN
           TRUE
@@ -107,14 +108,16 @@ const buildSQL = function buildSQL(profile, geoid, compare) {
       END AS change_percentage_point_significant,
 
       -- significant --
+      -- (actually reflect reliability, issue #57) --
       CASE
         WHEN ((((difference_m) / 1.645) / nullif(ABS(difference_sum), 0)) * 100) < 20 THEN true
         ELSE false
       END AS significant,
 
       -- percent_significant --
+      -- (actually reflect reliability, issue #57) --
       CASE
-        WHEN ((((difference_percent_m) / 1.645) / nullif(ABS(difference_percent), 0)) * 100) < 20 THEN 
+        WHEN ((((difference_percent_m) / 1.645) / nullif(ABS(difference_percent), 0)) * 100) < 20 THEN
           true
         ELSE false
       END AS percent_significant
@@ -155,6 +158,7 @@ const buildSQL = function buildSQL(profile, geoid, compare) {
         END AS change_percentage_point_m,
 
         -- change_significant --
+        -- (actually reflect reliability, issue #57) --
         CASE
           WHEN ((((change_m) / 1.645) / nullif(ABS(change_sum), 0)) * 100) < 20 THEN
             TRUE
@@ -163,6 +167,7 @@ const buildSQL = function buildSQL(profile, geoid, compare) {
         END AS change_significant,
 
         -- change_percent_significant --
+        -- (actually reflect reliability, issue #57) --
         CASE
           WHEN ((((change_percent_m) / 1.645) / nullif(ABS(change_percent), 0)) * 100) < 20 THEN
             TRUE

--- a/query-helpers/profile.js
+++ b/query-helpers/profile.js
@@ -142,13 +142,15 @@ const buildSQL = function buildSQL(profile, ids, compare) {
       *,
 
       -- significant --
+      -- (actually reflect reliability, issue #57) --
       CASE
-        WHEN ((((difference_m) / 1.645) / nullif(ABS(difference_sum), 0)) * 100) < 20 
+        WHEN ((((difference_m) / 1.645) / nullif(ABS(difference_sum), 0)) * 100) < 20
         THEN true
         ELSE false
       END AS significant,
 
       -- percent_significant --
+      -- (actually reflect reliability, issue #57) --
       CASE
         WHEN ((((difference_percent_m) / 1.645) / nullif(ABS(difference_percent), 0)) * 100) < 20
         THEN true
@@ -156,6 +158,7 @@ const buildSQL = function buildSQL(profile, ids, compare) {
       END AS percent_significant,
 
       -- change_percent_significant --
+      -- (actually reflect reliability, issue #57) --
       CASE
         WHEN ((((change_percent_m) / 1.645) / nullif(ABS(change_percent), 0)) * 100) < 20 THEN
           TRUE
@@ -164,6 +167,7 @@ const buildSQL = function buildSQL(profile, ids, compare) {
       END AS change_percent_significant,
 
       -- change_percentage_point_significant --
+      -- (actually reflect reliability, issue #57) --
       CASE
         WHEN ((((change_percentage_point_m) / 1.645) / nullif(ABS(change_percentage_point), 0)) * 100) < 20 THEN
           TRUE
@@ -171,7 +175,7 @@ const buildSQL = function buildSQL(profile, ids, compare) {
           FALSE
       END AS change_percentage_point_significant
 
-    FROM ( 
+    FROM (
       SELECT
         *,
 
@@ -207,6 +211,7 @@ const buildSQL = function buildSQL(profile, ids, compare) {
         END AS change_percentage_point_m,
 
         -- change_significant --
+        -- (actually reflect reliability, issue #57) --
         CASE
           WHEN ((((change_m) / 1.645) / nullif(ABS(change_sum), 0)) * 100) < 20 THEN
             TRUE
@@ -294,7 +299,7 @@ const buildSQL = function buildSQL(profile, ids, compare) {
                 ) * 1.645,
                 0
               )
-            ELSE 
+            ELSE
               null
           END AS change_percent_m
 

--- a/routes/profile.js
+++ b/routes/profile.js
@@ -80,7 +80,8 @@ const appendIsReliable = data => (data.map((row) => {
   if (codingThresholds.sum) appendedRow.is_reliable = false;
   if (codingThresholds.comparison_sum) appendedRow.comparison_is_reliable = false;
 
-  // calculate significance
+  // !!!!!! These calculations were changed from determining statistical SIGNIFICANCE to determining statistical RELIABILITY in PR #39, variable names were NOT updated to reflect this calculation change
+  // !!!!!! These names will be updated in a broader refactor of PFF, Visit issue #57 in labs-factfinder waffle to get more info
   appendedRow.significant = ((((difference_m) / 1.645) / Math.abs(difference_sum)) * 100) < 20;
   appendedRow.change_significant = ((((change_m) / 1.645) / Math.abs(change_sum)) * 100) < 20;
   appendedRow.change_percent_significant = ((((change_percent_m) / 1.645) / Math.abs(change_percent)) * 100) < 20;


### PR DESCRIPTION
References issue #57 . 

In PR #39, calculations were changed from determining SIGNIFICANCE to determining RELIABILITY, but variable names were not updated to reflect this change. Variable names will be updated during a broader refactor of PFF. As of now, comments were added to note this change. 