### PR TITLE
use-aliased-data

### DIFF
--- a/search-helpers/block.js
+++ b/search-helpers/block.js
@@ -21,7 +21,7 @@ const block = (string) => {
             WHEN borocode = '5' THEN '085'
           END
         || ct2010 || cb2010 as fips
-      FROM nyc_census_blocks_2010
+      FROM nyc_census_blocks
     ) x
     WHERE
       bctcb2010 LIKE '%25${string}%25'

--- a/search-helpers/neighborhood-tabulation-area.js
+++ b/search-helpers/neighborhood-tabulation-area.js
@@ -18,7 +18,7 @@ const neighborhood = (string) => {
       ntacode,
       ntacode as geolabel,
       ntacode as geoid
-    FROM support_admin_ntaboundaries
+    FROM nta_boundaries
     WHERE
       (
         LOWER(ntaname) LIKE LOWER('%25${string}%25')

--- a/search-helpers/tract.js
+++ b/search-helpers/tract.js
@@ -21,7 +21,7 @@ const tract = (string) => {
           END
         || ct2010 as fips,
         boroname || ' ' || ctlabel As boronamect
-      FROM nyc_census_tracts_2010
+      FROM nyc_census_tracts
     ) x
     WHERE
       boroct2010 LIKE '%25${string}%25'

--- a/selection-helpers/summary-levels.js
+++ b/selection-helpers/summary-levels.js
@@ -9,7 +9,7 @@ const summaryLevels = {
       bctcb2010,
       bctcb2010 AS geoid,
       (ct2010::float / 100)::text || '-' || cb2010 as geolabel
-    FROM nyc_census_blocks_2010
+    FROM nyc_census_blocks
   `,
 
   tracts: (webmercator = true) => `
@@ -21,7 +21,7 @@ const summaryLevels = {
       boroct2010,
       ntacode,
       boroct2010 AS geoid
-    FROM nyc_census_tracts_2010
+    FROM nyc_census_tracts
   `,
 
   ntas: (webmercator = true) => `
@@ -32,7 +32,7 @@ const summaryLevels = {
       ntaname || ' (' || ntacode || ')' as geolabel,
       borocode::text,
       ntacode AS geoid
-    FROM support_admin_ntaboundaries
+    FROM nta_boundaries
   `,
 
   pumas: (webmercator = true) => `


### PR DESCRIPTION
This PR updates Carto queries to query from aliased views of the latest dataset version. This reduces data maintenance overhead (now we only need to redefine the view when we get a new data version instead of find/replacing the table name throughout the code base) and makes this app match data view references used in all our other apps.

Related to https://github.com/NYCPlanning/labs-layers-api/pull/124