### PR TITLE
657: update top and bottom coding values

### DIFF
--- a/metadata/top-bottom-codings.js
+++ b/metadata/top-bottom-codings.js
@@ -16,8 +16,8 @@ const topBottomCodings = {
         lower: 2500,
       },
       nta: {
-        upper: 225000,
-        lower: 11000,
+        upper: 200000,
+        lower: 9999,
       },
     },
     mdfaminc: {
@@ -26,8 +26,8 @@ const topBottomCodings = {
         lower: 2500,
       },
       nta: {
-        upper: 225000,
-        lower: 11000,
+        upper: 200000,
+        lower: 9999,
       },
     },
     mdnfinc: {
@@ -36,8 +36,8 @@ const topBottomCodings = {
         lower: 2500,
       },
       nta: {
-        upper: 225000,
-        lower: 11000,
+        upper: 200000,
+        lower: 9999,
       },
     },
     mdewrk: {
@@ -46,8 +46,8 @@ const topBottomCodings = {
         lower: 2500,
       },
       nta: {
-        upper: 112500,
-        lower: 2800,
+        upper: 100000,
+        lower: 2499,
       },
     },
     mdemftwrk: {
@@ -56,8 +56,8 @@ const topBottomCodings = {
         lower: 2500,
       },
       nta: {
-        upper: 112500,
-        lower: 2800,
+        upper: 100000,
+        lower: 2499,
       },
     },
     mdefftwrk: {
@@ -66,8 +66,8 @@ const topBottomCodings = {
         lower: 2500,
       },
       nta: {
-        upper: 112500,
-        lower: 2800,
+        upper: 100000,
+        lower: 2499,
       },
     },
     mdrms: {


### PR DESCRIPTION
- revert all "Latest" values back to what was originally in master (should have never been changed)
- update top and bottom coding values for aggregated geographies ("nta" geography type) for 2006-2010 data ("earlier")
