### PR TITLE
Adds a migration for a change to the metadata schema EDM-side

### DIFF
--- a/migrations/1580836697651_add-sort-order-to-acs-metadata.js
+++ b/migrations/1580836697651_add-sort-order-to-acs-metadata.js
@@ -1,0 +1,11 @@
+exports.up = (pgm) => {
+  pgm.addColumns('factfinder_metadata', {
+    sort_order: {
+      type: 'integer',
+    },
+  });
+};
+
+exports.down = (pgm) => {
+  pgm.dropColumns('factfinder_metadata', ['sort_order']);
+};


### PR DESCRIPTION
This column is not used in the app, however, EDM and I added it while trying to debug some issues. We found that sorting was not the source of the issue.

Instead of reverting the schema change, this commit keeps the migration. It’s necessary still because any schema changes EDM-side will cause the foreign data wrappers to fail, preventing future refreshes.

During a later refactor, it should be used as an identifier to assist with explicit sorting.
