### PR TITLE
Throw error (rather than silence log); improve error msg

### DIFF
--- a/routes/profile.js
+++ b/routes/profile.js
@@ -25,7 +25,10 @@ router.get('/:id/:profileName', async (req, res) => {
     return res.send(profileObj);
   } catch (e) {
     console.log(e); // eslint-disable-line
-    return res.status(500).send({ error: 'Failed to create profile' });
+
+    return res.status(500).send({
+      errors: [`Failed to create profile: ${e}`],
+    });
   }
 });
 

--- a/utils/data-processor.js
+++ b/utils/data-processor.js
@@ -76,7 +76,10 @@ class DataProcessor {
         this.recalculateIsReliable(row, wasCoded);
       }
     } catch (e) {
-      console.log(`Failed to update special vars for ${row.variable}:`, e); // eslint-disable-line
+      throw new Error(`
+        Failed to update special vars for ${row.variable}:
+        ${e}
+      `);
     }
   }
 

--- a/utils/interpolate.js
+++ b/utils/interpolate.js
@@ -17,7 +17,11 @@ function interpolate(data, variable, year) {
   const scenario = bins.map((bin) => {
     const [key, range] = bin;
     const [min, max] = range;
-    const { sum } = find(data, ['variable', key]);
+    const row = find(data, ['variable', key]);
+
+    if (!row) throw new Error(`${key} was not found in the ${year} dataset.`);
+
+    const { sum } = row;
 
     return {
       quantity: sum,


### PR DESCRIPTION
Many errors were being swallowed in the logs and returning improper data. This change explicitly throws an error when data returned from the database is incorrect. This helps prevent the app from silently returning totally wrong data.

This change also adds some helpful logging to debug quicker.
