### PR TITLE
736 decennial change over time

### DIFF
--- a/utils/change.js
+++ b/utils/change.js
@@ -21,26 +21,16 @@ function calculateChanges(row) {
   // explicitly set changes to null if:
   // - any estimates are missing
   // - either estimate or previous estimate was coded
-  // - the profile is NOT decennial
-  const isDecennial = (row.profile === 'decennial');
-  const shouldNullify = (!allExist(row.sum, row.previous_sum, row.m, row.previous_m)
-      || row.codingThreshold
-      || row.previous_codingThreshold) && !isDecennial;
-
-  if (shouldNullify) {
+  if (!allExist(row.sum, row.previous_sum, row.m, row.previous_m)
+    || row.codingThreshold
+    || row.previous_codingThreshold) {
     nullChanges(row);
-
     return;
   }
-
   row.change_sum = executeFormula('delta', [row.sum, row.previous_sum]);
+  row.change_m = executeFormula('delta_m', [row.m, row.previous_m]);
 
-  // reliability calculations do not apply to decennial.
-  if (!isDecennial) {
-    row.change_m = executeFormula('delta_m', [row.m, row.previous_m]);
-
-    if (row.change_sum !== 0) row.change_significant = executeFormula('significant', [row.change_sum, row.change_m]);
-  }
+  if (row.change_sum !== 0) row.change_significant = executeFormula('significant', [row.change_sum, row.change_m]);
 }
 
 /*

--- a/utils/difference.js
+++ b/utils/difference.js
@@ -17,21 +17,35 @@ function calculateDifferences(row) {
   // explicitly set differences to null if:
   // - any estimates are missing
   // - either estimate or comparison estimate was coded
-  if (!allExist(row.sum, row.comparison_sum, row.m, row.comparison_m)
-    || row.codingThreshold
-    || row.comparison_codingThreshold) {
+  const {
+    sum,
+    comparison_sum,
+    m,
+    comparison_m,
+  } = row;
+
+  const isDecennial = row.profile === 'decennial';
+  const hasValidInputs = allExist(sum, comparison_sum, m, comparison_m)
+  const shouldNullify = (!hasValidInputs 
+    || row.codingThreshold // TODO: why is this here?
+    || row.comparison_codingThreshold // TODO: why is this here?
+  ) && !isDecennial;
+
+  if (shouldNullify) {
     nullDifferences(row);
+  } else {
+    row.difference_sum = executeFormula('delta', [row.sum, row.comparison_sum]);
 
     // special handling for 'decennial' rows, which do not have MOE and are all considered 'significant'
-    if (row.profile === 'decennial') row.significant = true;
-    return;
+    if (isDecennial) {
+      row.significant = true;
+    } else {
+      row.difference_m = executeFormula('delta_m', [row.m, row.comparison_m]);
+
+      // TODO rename difference_significant
+      if (row.difference_sum !== 0) row.significant = executeFormula('significant', [row.difference_sum, row.difference_m]);
+    }
   }
-
-  row.difference_sum = executeFormula('delta', [row.sum, row.comparison_sum]);
-  row.difference_m = executeFormula('delta_m', [row.m, row.comparison_m]);
-
-  // TODO rename difference_significant
-  if (row.difference_sum !== 0) row.significant = executeFormula('significant', [row.difference_sum, row.difference_m]);
 }
 
 /*
@@ -43,19 +57,29 @@ function calculateDifferencePercents(row) {
   // - any percent estimates are missing
   // - either estimate or comparison estimate was coded
   // - both estimate and previous estimate are 0
-  if (!allExist(row.percent, row.comparison_percent, row.percent_m, row.comparison_percent_m)
-    || row.codingThreshold
-    || row.comparison_codingThreshold
-    || (row.sum === 0 && row.comparison_sum === 0)) {
+  const {
+    percent,
+    comparison_percent,
+    percent_m,
+    comparison_percent_m,
+  } = row;
+
+  const isDecennial = row.profile === 'decennial';
+  const hasValidInputs = allExist(percent, comparison_percent, percent_m, comparison_percent_m);
+  const shouldNullify = !hasValidInputs && !isDecennial;
+
+  if (shouldNullify) {
     nullDifferencePercents(row);
-    return;
+  } else {
+    row.difference_percent = executeFormula('delta_with_threshold', [row.percent * 100, row.comparison_percent * 100]);
+
+    if (!isDecennial) {
+      row.difference_percent_m = executeFormula('delta_m', [row.percent_m * 100, row.comparison_percent_m * 100]);
+
+      // TODO rename difference_percent_significant
+      if (row.difference_percent !== 0) row.percent_significant = executeFormula('significant', [row.difference_percent, row.difference_percent_m]);
+    }
   }
-
-  row.difference_percent = executeFormula('delta_with_threshold', [row.percent * 100, row.comparison_percent * 100]);
-  row.difference_percent_m = executeFormula('delta_m', [row.percent_m * 100, row.comparison_percent_m * 100]);
-
-  // TODO rename difference_percent_significant
-  if (row.difference_percent !== 0) row.percent_significant = executeFormula('significant', [row.difference_percent, row.difference_percent_m]);
 }
 
 /*
@@ -86,4 +110,5 @@ function nullDifferencePercents(row) {
 function allExist(...vals) {
   return vals.every(val => val !== undefined && val !== null);
 }
+
 module.exports = doDifferenceCalculations;

--- a/utils/difference.js
+++ b/utils/difference.js
@@ -17,31 +17,21 @@ function calculateDifferences(row) {
   // explicitly set differences to null if:
   // - any estimates are missing
   // - either estimate or comparison estimate was coded
-  // - the profile is NOT decennial
-  const isDecennial = (row.profile == 'decennial');
-  const shouldNullify = (!allExist(row.sum, row.comparison_sum, row.m, row.comparison_m)
+  if (!allExist(row.sum, row.comparison_sum, row.m, row.comparison_m)
     || row.codingThreshold
-    || row.comparison_codingThreshold) && !isDecennial;
-
-  if (shouldNullify) {
+    || row.comparison_codingThreshold) {
     nullDifferences(row);
 
+    // special handling for 'decennial' rows, which do not have MOE and are all considered 'significant'
+    if (row.profile === 'decennial') row.significant = true;
     return;
   }
 
   row.difference_sum = executeFormula('delta', [row.sum, row.comparison_sum]);
+  row.difference_m = executeFormula('delta_m', [row.m, row.comparison_m]);
 
-  if (isDecennial) {
-    row.significant = true;
-  }
-
-  // special handling for 'decennial' rows, which do not have MOE and are all considered 'significant'
-  if (!isDecennial) {
-    row.difference_m = executeFormula('delta_m', [row.m, row.comparison_m]);
-
-    // TODO rename difference_significant
-    if (row.difference_sum !== 0) row.significant = executeFormula('significant', [row.difference_sum, row.difference_m]);
-  }
+  // TODO rename difference_significant
+  if (row.difference_sum !== 0) row.significant = executeFormula('significant', [row.difference_sum, row.difference_m]);
 }
 
 /*


### PR DESCRIPTION
Previously, decennial change/difference calculations weren’t being made because the code did not take into account that difference in sum calculations may still be performed on decennial profiles withOUT the need for reliability statistics. this is because decennial census data is not sampled and doesn’t include error.

Now, the logic considers the type of profile (decennial) and allows for calculating the change/difference in sum for decennial profiles.

This commit also refactors some of the code is it’s a little easier to follow and exposes the complexity more clearly...