### PR TITLE
Multiply the sum_ratio result by 100

### DIFF
--- a/utils/formulas.js
+++ b/utils/formulas.js
@@ -21,7 +21,7 @@ module.exports = {
   /** *** sum calculations **** */
   sum: (aggSum, universe) => `GET("${aggSum}.sum") / GET("${universe}.sum")`,
   // special mean calculation for 'ratio' type values TODO: get a better name for ratio
-  sum_ratio: (observed, universe) => `GET("${observed}.sum") / (GET("${observed}.sum") + GET("${universe}.sum"))`,
+  sum_ratio: (observed, universe) => `GET("${observed}.sum") / (GET("${observed}.sum") + GET("${universe}.sum")) * 100`,
 
   /** *** margin of error calculations **** */
   m: (aggSum, universe) => `(1/GET("${universe}.sum")) * SQRT((GET("${aggSum}.m")^2) + ((GET("${aggSum}.sum") / GET("${universe}.sum"))^2 * (GET("${universe}.m")^2)))`,


### PR DESCRIPTION
This multiplies the sum ratio result by 100 so that it is displayed as a whole number for presentation purposes.

Closes https://github.com/NYCPlanning/labs-factfinder/issues/742
