### PR TITLE
Wrap calculations in try/catch to skip invalid inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,14 @@ You will need the following things properly installed on your computer.
 
 - [Git](https://git-scm.com/)
 - [Node.js](https://nodejs.org/) (with NPM)
+- Nodemon
 
 ## Local development
 
 - Clone this repo `https://github.com/NYCPlanning/labs-factfinder-api.git`
 - Install Dependencies `yarn install`
 - Create `.env` file based on `.env-example` with your mongo uri and postgresql connection string
+  - A .env file may be found on 1pass
 - Start the server `npm run devstart`
 
 ## Architecture

--- a/routes/profile.js
+++ b/routes/profile.js
@@ -65,8 +65,20 @@ async function getProfileData(profileName, geoids, compare, db) {
   return profileData
     .map((row) => {
       const rowConfig = find(specialCalculationConfigs[profileName], ['variable', row.variable]);
-      doChangeCalculations(row, rowConfig);
-      doDifferenceCalculations(row);
+
+      // wrap in a try catch in case something goes wrong.
+      // TODO: this was added as a stopgap for known issues
+      //    with decennial variables (for example, certain race
+      //    categories were missing). we should more explicitly
+      //    validate those decennial inputs instead of a general
+      //    purpose try/catch.
+      try {
+        doChangeCalculations(row, rowConfig);
+        doDifferenceCalculations(row);
+      } catch (e) {
+        console.log(`Something went wrong calculating ${row.variable}: ${e}`);
+      }
+
       return row;
     });
 }

--- a/utils/change.js
+++ b/utils/change.js
@@ -30,7 +30,7 @@ function calculateChanges(row) {
     previous_codingThreshold,
   } = row;
 
-  const isDecennial = row.profile === 'decennial';
+  const isDecennial = row.profile === 'decennial'; // TODO: check for valid decennial inputs
   const hasValidInputs = allExist(sum, previous_sum, m, previous_m);
   const shouldNullify = (!hasValidInputs
     || codingThreshold // TODO: Why is this part of it?


### PR DESCRIPTION
Certain decennial change calculations were failing because they were new categories that could not be compared to previous releases.

This change wraps the calculations code in a try/catch to prevent failure. Note that this should be changed later to more explicitly validate decennial inputs, and skip accordingly.

<!-- Be sure to merge the latest from `develop` and make sure your tests pass -->
