### PR TITLE
4203 adding a new route for support geoids based on support_geoids 

### DIFF
--- a/app.js
+++ b/app.js
@@ -33,6 +33,7 @@ app.use(compression());
 app.use('/search', require('./routes/search'));
 app.use('/selection', require('./routes/selection'));
 app.use('/profile', require('./routes/profile'));
+app.use('/support-geoids', require('./routes/support-geoids'));
 
 app.use((req, res) => {
   res.status(404).json({

--- a/routes/support-geoids.js
+++ b/routes/support-geoids.js
@@ -1,0 +1,11 @@
+const express = require('express');
+
+const router = express.Router();
+
+router.get('/', async (req, res) => {
+  const { app } = req;
+  const supportGeoids = await app.db.query('SELECT geoid, geotype, label, typelabel FROM support_geoids');
+  return res.send({ supportGeoids });
+});
+
+module.exports = router;


### PR DESCRIPTION
<!-- Be sure to merge the latest from `develop` and make sure your tests pass -->

This PR is aimed to replace the frontend [geography-query](https://github.com/NYCPlanning/labs-factfinder/blob/5a85aa791d719839c3073bae511b79e0ca220276/app/queries/geography-options.js)
 

## Changes Proposed:
- New Feature:
   new route proposed 
  `/support-geoids` which will return a list of geoids, geotype, geogname and labels
  e.g. 
```json
{
    "supportGeoids": [
        {
            "geoid": "0",
            "geotype": "City2020",
            "label": "New York City",
            "typelabel": "City %26 Boroughs"
        },
        {
            "geoid": "2",
            "geotype": "Boro2020",
            "label": "Bronx",
            "typelabel": "City %26 Boroughs"
        }
]
```
- API change
- New Domain-specific language
   `support-geoids`: a table of higher level geographies with translation between geoid and geogname (currently including city, borough, NTA, CDTA) 
- Refactor of existing code

## Note: 
The new support-geoids table will be generated by EDM and included in the migration process (it will be stored in postgres along with the acs tables and metadata tables)

## work Items:
- [4203](https://dev.azure.com/NYCPlanning/ITD/_workitems/edit/4203)
- [4206](https://dev.azure.com/NYCPlanning/ITD/_workitems/edit/4206)