### PR TITLE
4401 Include previous_comparison and previous_difference in Profile payload model 

### DIFF
--- a/routes/profile.js
+++ b/routes/profile.js
@@ -100,7 +100,7 @@ async function getProfileData(profileName, geoids, compare, db) {
   const profileData = new DataProcessor(rawProfileData, profileName, isAggregate).process();
   const compareProfileData = new DataProcessor(rawCompareProfileData, profileName, /* isAggregate */ false).process();
   const previousProfileData = new DataProcessor(rawPreviousProfileData, profileName, isAggregate, /* isPrevious */ true).process();
-  const previousCompareProfileData = new DataProcessor(rawPreviousCompareProfileData, profileName, isAggregate, /* isPrevious */ true).process();
+  const previousCompareProfileData = new DataProcessor(rawPreviousCompareProfileData, profileName, false, /* isPrevious */ true).process();
 
   // add previousProfileData and compareProfileData row objects into profileData row objects
   join(profileData, compareProfileData, previousProfileData, previousCompareProfileData);

--- a/utils/difference.js
+++ b/utils/difference.js
@@ -6,7 +6,9 @@ const { executeWithValues: executeFormula } = require('./formula');
  */
 function doDifferenceCalculations(row) {
   calculateDifferences(row);
+  calculatePreviousDifferences(row);
   calculateDifferencePercents(row);
+  calculatePreviousDifferencePercents(row);
 }
 
 /*
@@ -26,7 +28,7 @@ function calculateDifferences(row) {
 
   const isDecennial = row.profile === 'decennial';
   const hasValidInputs = allExist(sum, comparison_sum, m, comparison_m)
-  const shouldNullify = (!hasValidInputs 
+  const shouldNullify = (!hasValidInputs
     || row.codingThreshold // TODO: why is this here?
     || row.comparison_codingThreshold // TODO: why is this here?
   ) && !isDecennial;
@@ -44,6 +46,38 @@ function calculateDifferences(row) {
 
       // TODO rename difference_significant
       if (row.difference_sum !== 0) row.significant = executeFormula('significant', [row.difference_sum, row.difference_m]);
+    }
+  }
+}
+
+function calculatePreviousDifferences(row) {
+  const {
+    previous_sum,
+    previous_comparison_sum,
+    previous_m,
+    previous_comparison_m,
+  } = row;
+
+  const isDecennial = row.profile === 'decennial';
+  const hasValidInputs = allExist(previous_sum, previous_comparison_sum, previous_m, previous_comparison_m)
+  const shouldNullify = (!hasValidInputs
+    || row.previous_codingThreshold // TODO: why is this here?
+    || row.previous_comparison_codingThreshold // TODO: why is this here?
+  ) && !isDecennial;
+
+  if (shouldNullify) {
+    nullPreviousDifferences(row);
+  } else {
+    row.previous_difference_sum = executeFormula('delta', [row.previous_sum, row.previous_comparison_sum]);
+
+    // special handling for 'decennial' rows, which do not have MOE and are all considered 'significant'
+    if (isDecennial) {
+      row.previous_significant = true;
+    } else {
+      row.previous_difference_m = executeFormula('delta_m', [row.previous_m, row.previous_comparison_m]);
+
+      // TODO rename difference_significant
+      if (row.previous_difference_sum !== 0) row.previous_significant = executeFormula('significant', [row.previous_difference_sum, row.previous_difference_m]);
     }
   }
 }
@@ -82,6 +116,38 @@ function calculateDifferencePercents(row) {
   }
 }
 
+function calculatePreviousDifferencePercents(row) {
+  const {
+    previous_percent,
+    previous_comparison_percent,
+    previous_percent_m,
+    previous_comparison_percent_m,
+  } = row;
+
+  const isDecennial = row.profile === 'decennial';
+  const hasValidInputs = allExist(
+    previous_percent,
+    previous_comparison_percent,
+    previous_percent_m,
+    previous_comparison_percent_m
+    );
+  const shouldNullify = !hasValidInputs && !isDecennial;
+
+  if (shouldNullify) {
+    nullPreviousDifferencePercents(row);
+  } else {
+    row.previous_difference_percent = executeFormula('delta_with_threshold', [row.previous_percent * 100, row.previous_comparison_percent * 100]);
+
+    if (!isDecennial) {
+      row.previous_difference_percent_m = executeFormula('delta_m', [row.previous_percent_m * 100, row.previous_comparison_percent_m * 100]);
+
+      // TODO rename difference_percent_significant
+      if (row.previous_difference_percent !== 0) row.previous_percent_significant = executeFormula('significant', [row.previous_difference_percent, row.previous_difference_percent_m]);
+    }
+  }
+}
+
+
 /*
  * Helper function to set difference values to null
  * @param{Object} row - The row to update
@@ -91,6 +157,11 @@ function nullDifferences(row) {
   row.difference_m = null;
 }
 
+function nullPreviousDifferences(row) {
+  row.previous_difference_sum = null;
+  row.previous_difference_m = null;
+}
+
 /*
  * Helper function to set difference percent values to null
  * @param{Object} row - The row to update
@@ -98,6 +169,12 @@ function nullDifferences(row) {
 function nullDifferencePercents(row) {
   row.difference_percent = null;
   row.difference_percent_m = null;
+}
+
+
+function nullPreviousDifferencePercents(row) {
+  row.previous_difference_percent = null;
+  row.previous_difference_percent_m = null;
 }
 
 


### PR DESCRIPTION
### Summary
This PR modifies the API so that the Profile endpoint will deliver comparison area and difference data when the user selects a "previous year" source  (e.g. 2010 for ACS). 

In the screenshot below, it is the data for the middle "New York City" (comparison) and right hand side "Difference" columns.
![image](https://user-images.githubusercontent.com/3311663/129282257-7aa63d59-05a7-406f-addf-defb639a60bf.png)

Previously, only the current year (2020) source delivered comparison area and comparison data. The Change over Time source delivered only "change" data, which is the diff between previous and current year "selected area" data. 


In the table below, it is the middle row, last two columns of data that was missing from the payload. 

![image](https://user-images.githubusercontent.com/3311663/129282117-3de3a642-5469-4713-9e10-e56c651022a3.png)

Frontend PR https://github.com/NYCPlanning/labs-factfinder/pull/869 subsequently will display these newly added variables. 


#### Tasks/Bug Numbers
Fixes [AB#4401](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/4401) [AB#2125](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/2125)

### Technical Explanation
Currently the Profile payload is an array of Row objects, each of which represents the entire table in the diagram above, but flattened out (denormalized). The Row object uses attribuet prefixes to distinguish between different components of data. E.g.:
```
 [ 
    {
          Current_selection
          Current_comparison
          current_difference,
          previous_selection
          previous_comparison
          previous_difference,
          change_selection
     }....
```

This is really messy, ugly and yields a lot of dupliceate heavy code. and ideally we normalize it, composing the table using more discrete, composable models. @SPTKL  and I spiked this but unfortunately the frontend is still very tied to a flattened model being delivered, and it would be too much scope to refactor the frontend and backend now to use decomposed models (Base, Difference, Change, etc). 
