### PR TITLE
4589 Create new geo-options endpoint

### DIFF
--- a/app.js
+++ b/app.js
@@ -33,6 +33,7 @@ app.use(compression());
 app.use('/search', require('./routes/search'));
 app.use('/selection', require('./routes/selection'));
 app.use('/profile', require('./routes/profile'));
+app.use('/geo-options', require('./routes/geo-options'));
 
 app.use((req, res) => {
   res.status(404).json({

--- a/routes/geo-options.js
+++ b/routes/geo-options.js
@@ -1,0 +1,13 @@
+const express = require('express');
+
+const router = express.Router();
+
+router.get('/', async (req, res) => {
+  const { app } = req;
+
+  const geoOptions = await app.db.query('SELECT geoid, geotype, label, typelabel FROM support_geoids');
+
+  return res.send(geoOptions);
+});
+
+module.exports = router;


### PR DESCRIPTION
### Summary
Creates a new `geo-options` GET endpoint that will query the `support_geoids` table within the PFF Postgres database, and return all results as an array. 

The `support_geoids` table is basically a lookup of geoids to their appropriate human-readable label. For example, 0 -> New York City. 

Previously, `support_geoids` lived in Carto. With @SPTKL 's help we moved it into the Postgres so all of our required tables can live under the same roof for easier future maintenance. 

This route is named `geo-options` to keep it generic and multipurpose, but the PFF frontend specifically uses the list as a list of available comparison geography options.

Pairs with frontend PR https://github.com/NYCPlanning/labs-factfinder/pull/875

#### Tasks/Bug Numbers
Fixes [AB#4589](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/4589)

### Any other info you think would help a reviewer understand this PR?
We should probably rename the `support_geoids` table to something like `geoid-lookup` to be more semantic. 
