### PR TITLE
4676 Search results fail to load

### DIFF
--- a/search-helpers/district.js
+++ b/search-helpers/district.js
@@ -5,7 +5,7 @@ const district = (string) => {
     SELECT * FROM (
       SELECT
         the_geom,
-        borocd AS geolabel,
+        CAST(borocd AS varchar) AS geolabel,
         borocd AS geoid
       FROM nycd2020
     ) x


### PR DESCRIPTION
<!---
   The below template is a general guide, but not a strict prescription!
-->

### Summary
Search results were not loading because of an issue when searching the district geography type.

#### Tasks/Bug Numbers
 - Fixes [AB#4676](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/4676)


### Technical Explanation
The table was returning results as a number, which was causing an issue as it was being compared against a string.  The number is now being cast as a string so that the comparison works correctly, allowing for the results to load.

### Any other info you think would help a reviewer understand this PR?
