### PR TITLE
4608 Use official geographies from BYTES

### DIFF
--- a/search-helpers/block.js
+++ b/search-helpers/block.js
@@ -22,7 +22,7 @@ const block = (string) => {
             WHEN borocode = '5' THEN '085'
           END
         || ct2020 || cb2020 as fips
-      FROM nycb2020_fixed
+      FROM pff_2020_census_blocks_21c
     ) x
     WHERE
       bctcb2020 LIKE '%25${string}%25'

--- a/search-helpers/borough.js
+++ b/search-helpers/borough.js
@@ -8,7 +8,7 @@ const borough = (string) => {
         boroname as geolabel,
         boroname,
         borocode AS geoid,
-      FROM nybb2020
+      FROM pff_2020_boroughs_21c
     ) x
     WHERE
       boroname LIKE '%25${string}%25'

--- a/search-helpers/cdta.js
+++ b/search-helpers/cdta.js
@@ -20,7 +20,7 @@ const cdta = (string) => {
           END
         || countyfips as fips,
         boroname || ' '
-      FROM nycdta2020
+      FROM pff_2020_cdtas_21c
     ) x
     WHERE
       cdta2020 LIKE '%25${string}%25'

--- a/search-helpers/district.js
+++ b/search-helpers/district.js
@@ -7,7 +7,7 @@ const district = (string) => {
         the_geom,
         CAST(borocd AS varchar) AS geolabel,
         borocd AS geoid
-      FROM nycd2020
+      FROM pff_2020_community_districts_21c
     ) x
     WHERE
       geolabel LIKE '%25${string}%25'

--- a/search-helpers/neighborhood-tabulation-area.js
+++ b/search-helpers/neighborhood-tabulation-area.js
@@ -18,7 +18,7 @@ const neighborhood = (string) => {
       nta2020,
       nta2020 as geolabel,
       nta2020 as geoid
-    FROM nynta2020
+    FROM pff_2020_ntas_21c
     WHERE
       (
         LOWER(ntaname) LIKE LOWER('%25${string}%25')

--- a/search-helpers/tract.js
+++ b/search-helpers/tract.js
@@ -21,7 +21,7 @@ const tract = (string) => {
           END
         || ct2020 as fips,
         boroname || ' ' || ctlabel As boronamect
-      FROM nyct2020
+      FROM pff_2020_census_tracts_21c
     ) x
     WHERE
       boroct2020 LIKE '%25${string}%25'

--- a/selection-helpers/summary-levels.js
+++ b/selection-helpers/summary-levels.js
@@ -9,7 +9,7 @@ const summaryLevels = {
       bctcb2020,
       geoid AS geoid,
       bctcb2020 as geolabel
-    FROM nycb2020_fixed
+    FROM pff_2020_census_blocks_21c
   `,
 
   tracts: (webmercator = true) => `
@@ -21,7 +21,7 @@ const summaryLevels = {
       nta2020,
       boroct2020 AS geoid,
       borocode::text
-    FROM nyct2020
+    FROM pff_2020_census_tracts_21c
   `,
 
   cdtas: (webmercator = true) => `
@@ -33,7 +33,7 @@ const summaryLevels = {
       boroname,
       borocode::text,
       cdta2020 AS geoid
-    FROM nycdta2020
+    FROM pff_2020_cdtas_21c
   `,
 
   districts: (webmercator = true) => `
@@ -42,7 +42,7 @@ const summaryLevels = {
       borocd as geolabel,
       borocd AS geoid,
       substring(borocd, 0, 1) as borocode
-    FROM nycd2020
+    FROM pff_2020_community_districts_21c
   `,
 
   boroughs: (webmercator = true) => `
@@ -50,7 +50,7 @@ const summaryLevels = {
       ${webmercator ? 'the_geom_webmercator' : 'the_geom'},
       boroname as geolabel,
       borocode AS geoid
-    FROM nybb2020
+    FROM pff_2020_boroughs_21c
   `,
 
   cities: (webmercator = true) => `
@@ -58,7 +58,7 @@ const summaryLevels = {
       ${webmercator ? 'the_geom_webmercator' : 'the_geom'},
       city as geolabel,
       city AS geoid
-    FROM nycity2020
+    FROM pff_2020_city_21c
   `,
 
   ntas: (webmercator = true) => `
@@ -69,7 +69,7 @@ const summaryLevels = {
       nta2020 as geolabel,
       nta2020 AS geoid,
       borocode::text
-    FROM nynta2020
+    FROM pff_2020_ntas_21c
     WHERE ntaname NOT ILIKE 'park-cemetery-etc%25'
       AND ntaname != 'Airport'
   `,


### PR DESCRIPTION
<!---
   The below template is a general guide, but not a strict prescription!
-->

### Summary
This update replaces the CARTO tables temporarily being used with the finalized version of the data from BYTES.

#### Tasks/Bug Numbers
 - Closes [AB#4608](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/4608)


### Technical Explanation
The updated table names are as follows:
Geo | Old Name | New Name
Census Tract | nyct2020 | pff_2020_census_tracts_21c
NTA | nynta2020 | pff_2020_ntas_21c
CDTA | nycdta2020 | pff_2020_cdtas_21c
District | nycd2020 | pff_2020_community_districts_21c
Census Block | nycb2020_fixed | pff_2020_census_blocks_21c
Borough | nybb2020 | pff_2020_boroughs_21c
City | nycity2020 | pff_2020_city_21c



### Any other info you think would help a reviewer understand this PR?
