### PR TITLE
4281 Dynamic segments for geotype and geoid

### DIFF
--- a/routes/profile.js
+++ b/routes/profile.js
@@ -46,14 +46,12 @@ function prefixObj(row, prefix) {
   }
 }
 
-router.get('/:id/', async (req, res) => {
+router.get('/:geotype/:geoid/', async (req, res) => {
   const { app } = req;
-  let { id: _id } = req.params;
+
+  let { geotype, geoid } = req.params;
+
   const { compareTo = '0' } = req.query;
-
-  let [ idPrefix, selectionId ] = _id.split('_');
-
-  const geotype = getGeotypeFromIdPrefix(idPrefix);
 
   if (geotype === null) {
     res.status(500).send({
@@ -62,7 +60,7 @@ router.get('/:id/', async (req, res) => {
   }
 
   if (geotype === 'boroughs') {
-    selectionId = convertBoroughLabelToCode(selectionId);
+    geoid = convertBoroughLabelToCode(geoid);
   }
 
   if (invalidCompare(compareTo)) res.status(500).send({ error: 'invalid compareTo param' });
@@ -72,7 +70,7 @@ router.get('/:id/', async (req, res) => {
 
     if (geotype === 'selection') {
       try {
-        const selection = await app.db.query('SELECT * FROM selection WHERE hash = ${selectionId}', { selectionId })
+        const selection = await app.db.query('SELECT * FROM selection WHERE hash = ${geoid}', { geoid })
 
         if (selection && selection.length > 0) {
           // TODO: remove "profile" argument, and corresponding parameter in upstream functions
@@ -81,11 +79,11 @@ router.get('/:id/', async (req, res) => {
         }
       } catch(e) {
         return res.status(500).send({
-          errors: [`Failed to find selection for hash ${selectionId}. ${e}`],
+          errors: [`Failed to find selection for hash ${geoid}. ${e}`],
         });
       }
    } else {
-    profileObj = await getProfileData("demographic", [ selectionId ], compareTo, app.db);
+    profileObj = await getProfileData("demographic", [ geoid ], compareTo, app.db);
    }
 
     return res.send(profileObj);

--- a/routes/profile.js
+++ b/routes/profile.js
@@ -7,7 +7,6 @@ const specialCalculationConfigs = require('../special-calculations');
 const DataProcessor = require('../utils/data-processor');
 const doChangeCalculations = require('../utils/change');
 const doDifferenceCalculations = require('../utils/difference');
-const getGeotypeFromIdPrefix = require('../utils/geotype-from-id-prefix');
 
 const router = express.Router();
 

--- a/routes/selection.js
+++ b/routes/selection.js
@@ -56,7 +56,7 @@ router.get('/:geotype/:geoid', async (req, res) => {
 
       if (selection && selection.length > 0) {
         const {
-          _type: selectionGeotype,
+          geotype: selectionGeotype,
           geoids: selectionGeoids
         } = selection[0];
 
@@ -105,7 +105,7 @@ router.post('/', async (req, res) => {
   body.geoids.sort();
 
   const {
-    _type,
+    geotype,
     geoids
   } = body;
 
@@ -127,8 +127,8 @@ router.post('/', async (req, res) => {
     } else {
       try {
         await app.db.tx(t => t.none(
-          'INSERT INTO selection(_type, geoids, hash) VALUES(${_type}, ${geoids}, ${hash})',
-          { _type, geoids, hash },
+          'INSERT INTO selection(geotype, geoids, hash) VALUES(${geotype}, ${geoids}, ${hash})',
+          { geotype, geoids, hash },
         ));
 
         try {

--- a/routes/selection.js
+++ b/routes/selection.js
@@ -1,7 +1,6 @@
 const express = require('express');
 const sha1 = require('sha1');
 const carto = require('../utils/carto');
-const getGeotypeFromIdPrefix = require('../utils/geotype-from-id-prefix');
 
 const summaryLevels = require('../selection-helpers/summary-levels');
 
@@ -37,13 +36,9 @@ function convertBoroughLabelToCode(potentialBoroughLabel) {
   }
 }
 
-router.get('/:id', async (req, res) => {
+router.get('/:geotype/:geoid', async (req, res) => {
   const { app } = req;
-  let { id: _id } = req.params;
-
-  let [ idPrefix, selectionId ] = _id.split('_');
-
-  const geotype = getGeotypeFromIdPrefix(idPrefix);
+  let { geotype, geoid } = req.params;
 
   if (geotype === null) {
     res.send({
@@ -52,25 +47,25 @@ router.get('/:id', async (req, res) => {
   }
 
   if (geotype === 'boroughs') {
-    selectionId = convertBoroughLabelToCode(selectionId);
+    geoid = convertBoroughLabelToCode(geoid);
   }
 
   if (geotype === 'selection') {
     try {
-      const selection =  await app.db.query('SELECT * FROM selection WHERE hash = ${selectionId}', { selectionId });
+      const selection =  await app.db.query('SELECT * FROM selection WHERE hash = ${geoid}', { geoid });
 
       if (selection && selection.length > 0) {
         const {
-          _type: type,
-          geoids
+          _type: selectionGeotype,
+          geoids: selectionGeoids
         } = selection[0];
 
-        getFeatures(type, geoids)
+        getFeatures(selectionGeotype, selectionGeoids)
           .then((features) => {
             res.send({
               status: 'success',
-              id: selectionId,
-              type,
+              id: geoid,
+              type: selectionGeotype,
               features,
             });
           })
@@ -88,11 +83,11 @@ router.get('/:id', async (req, res) => {
       });
     }
   } else {
-    getFeatures(geotype, [ selectionId ])
+    getFeatures(geotype, [ geoid ])
       .then((features) => {
         res.send({
           status: 'success',
-          id: _id,
+          id: geoid,
           type: geotype,
           features,
         });
@@ -127,7 +122,7 @@ router.post('/', async (req, res) => {
 
       res.send({
         status: 'existing selection found',
-        id: `SID_${hash}`,
+        id: hash,
       });
     } else {
       try {
@@ -144,7 +139,7 @@ router.post('/', async (req, res) => {
 
             res.send({
               status: 'New Selection saved',
-              id: `SID_${hash}`,
+              id: hash,
               hash,
             });
           } else {


### PR DESCRIPTION
### Summary
Changes Selection and Profile endpoints to have :geotype and :geoid dynamic segments, replacing the previous Factfinder ID. 

See updated README for new API. 

Pairs with https://github.com/NYCPlanning/labs-factfinder/pull/881

Depends on/merge after https://github.com/NYCPlanning/labs-factfinder-api/pull/130

#### Tasks/Bug Numbers
 - Fixes [AB#4281](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/4281)

### Technical Explanation
<!---
  a. In technical terms, what was wrong, what is the fix, and why does it make things better? 
  b. If you can point to a specific line or file exhibiting the original problem, that would be great!
  c. Provide entrypoint of new solution, if different than (b).
  d. Provide overview of any new architecture.
       - How are components stringed together?
       - What is the new hierarchy? 
       - Any new components?
  e. Provide links and explanations for any new technical concepts, APIs and terms.
      Especially if you had to do some research yourself.
   List any ad-hoc, miscellaneous updates included
-->

### Any other info you think would help a reviewer understand this PR?
