### PR TITLE
District SQL Query Fix

### DIFF
--- a/selection-helpers/summary-levels.js
+++ b/selection-helpers/summary-levels.js
@@ -41,7 +41,7 @@ const summaryLevels = {
       ${webmercator ? 'the_geom_webmercator' : 'the_geom'},
       borocd as geolabel,
       borocd AS geoid,
-      substring(borocd, 0, 1) as borocode
+      substring(CAST(borocd AS text), 0, 1) as borocode
     FROM pff_2020_community_districts_21c
   `,
 


### PR DESCRIPTION
### Summary
Fixes error caused by attempting to take substring of an integer by casting it as a string.

#### Tasks/Bug Numbers
No ticket created

### Technical Explanation
Resolves the following error:
'{"error":["function pg_catalog.substring(integer, integer, integer) does not exist"],"hint":"No function matches the given name and argument types. You might need to add explicit type casts."}',

### Any other info you think would help a reviewer understand this PR?
