### PR TITLE
4725 Fix error "failed to update special vars for mdage"

### DIFF
--- a/utils/formula.js
+++ b/utils/formula.js
@@ -63,6 +63,11 @@ function executeWithData(data, variable, formulaName, args = []) {
 
   const { result, error } = parser.parse(formulaStr);
   if (error) {
+    // If this matches, it's a divide by zero error, which the world's greatest minds could not figure out how to fix in the cv formula
+    if((error==="#VALUE!") && (`${formulaName}`==="cv")) {
+      return 0;
+    }
+
     console.log(`${formulaStr}`);
     throw new Error(`${error}: ${formulaName}`);
   }


### PR DESCRIPTION
### Summary
Parser will now return 0 if getting an error calculating cv, which will happen if the sum is 0, as it causes an error attempting to divide by 0.

#### Tasks/Bug Numbers
 - Fixes [AB#4725](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/4725)

### Technical Explanation
It's a janky solution.  There may be a better solution by editing the formula for cv in utils/formulas.js, but I couldn't figure it out.  If you want to continue to chase this dream, here's the reference of available formulas: https://github.com/handsontable/formula-parser/blob/a29fc4d965a10b02e647b2cb5524adb3d35539e7/src/supported-formulas.js

### Any other info you think would help a reviewer understand this PR?
