### PR TITLE
4220 Lowercase base and variable to make sure percentages show up

### DIFF
--- a/query-helpers/acs.js
+++ b/query-helpers/acs.js
@@ -150,7 +150,7 @@ const acsProfileSQL = (ids, isPrevious = false) => `
     ORDER BY variable, base, category
   ) AS variables
   LEFT JOIN base
-  ON variables.base = base.base
+  ON LOWER(variables.base) = LOWER(base.base)
 `;
 
 module.exports = acsProfileSQL;

--- a/query-helpers/decennial.js
+++ b/query-helpers/decennial.js
@@ -40,7 +40,7 @@ const decennialProfileSQL = (ids, isPrevious = false) => `
     sum(value) as base_sum,
     relation as base
     FROM enriched_profile
-    WHERE relation = variable
+    WHERE LOWER(relation) = LOWER(variable)
     GROUP BY relation
   )
 
@@ -83,7 +83,7 @@ const decennialProfileSQL = (ids, isPrevious = false) => `
     GROUP BY variable, variablename, base, category
   ) decennial
   LEFT JOIN base
-  ON decennial.base = base.base
+  ON LOWER(decennial.base) = LOWER(base.base)
 `;
 
 module.exports = decennialProfileSQL;


### PR DESCRIPTION
### Summary
The new data tables lowercases all variable names and  base names, but the old tables did not. Thus percentages wouldn't show up. This is just a extra safeguard  to make sure the variable and base comparison works properly. 

#### Tasks/Bug Numbers
 - Fixes [AB#4220](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/4220)

### Technical Explanation

### Any other info you think would help a reviewer understand this PR?
