### PR TITLE
4725 Fix error yielded from recalculateCV

### DIFF
--- a/utils/data-processor.js
+++ b/utils/data-processor.js
@@ -133,9 +133,11 @@ class DataProcessor {
    * @param{boolean} wasCoded - Flag indicating if the estimate value has been coded
    */
   recalculateCV(row, config, wasCoded) {
-    // CV should not be computed for top- or bottom-coded values
-    const formulaName = getFormulaName(config.options, 'cv');
-    row.cv = wasCoded ? null : executeFormula(this.data, row.variable, formulaName, config.options.CVArgs);
+    if (this.isAggregate) {
+      // CV should not be computed for top- or bottom-coded values
+      const formulaName = getFormulaName(config.options, 'cv');
+      row.cv = wasCoded ? null : executeFormula(this.data, row.variable, formulaName, config.options.CVArgs);
+    } 
   }
 
   /*


### PR DESCRIPTION
### Summary
The recalculateCV function was running for single geoms (selections) when it shouldn't be. This was causing many of "failed to update sepcial vars" errors. This PR makes sure that function only runs when there are multiple geoms (a selection)

![image](https://user-images.githubusercontent.com/3311663/133680712-64d49b42-8fd0-4497-8abf-5fbefe003218.png)

```
((GET("m") / "1.645") / GET("sum")) * 100
Failed to update special vars for avgfmsz: Error: #VALUE!: cv
    at executeWithData (.../labs-factfinder-api/utils/formula.js:67:11)
    at DataProcessor.recalculateCV (.../labs-factfinder-api/utils/data-processor.js:138:32)
    at DataProcessor.recalculateSpecialVariables (.../labs-factfinder-api/utils/data-processor.js:75:14)
    at .../labs-factfinder-api/utils/data-processor.js:50:16
    at Array.forEach (<anonymous>)
    at DataProcessor.process (.../labs-factfinder-api/utils/data-processor.js:44:15)
    at getSurveyData (.../labs-factfinder-api/routes/survey.js:94:102)
    at processTicksAndRejections (internal/process/task_queues.js:97:5)
    at async .../labs-factfinder-api/routes/survey.js:58:19
 ...
 GET /survey/acs/ntas/MN0301?compareTo=BX1091 200 2036.363 ms - -
```
#### Tasks/Bug Numbers
 - Fixes [AB#4725](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/4725)
