### PR TITLE
Fixing special calculation error for decennial avghhsz: change hh1 to ochu_1

### DIFF
--- a/special-calculations/decennial.js
+++ b/special-calculations/decennial.js
@@ -31,7 +31,7 @@ module.exports = [
   {
     variable: 'avghhsz',
     specialType: 'mean',
-    options: { args: ['popinhh', 'hh1'] },
+    options: { args: ['popinhh', 'ochu_1'] },
   },
   {
     variable: 'avgfamsz',


### PR DESCRIPTION
based on Erica's commend on Teams: 
> for decennial `avghhsz`, using existing variables it would be `popinhh/ochu_1`.

The error occurred because `hh1` is not part of the PL release. Confirmed with Erica that we will use `ochu_1` instead
This should resolve this following error: 
![image](https://user-images.githubusercontent.com/13207770/133835878-6897362c-8fb6-436e-b397-a732cae5102e.png)
