### PR TITLE
Rewriting metadata migration to avoid "/usr/bin/psql: Argument list too long"

### DIFF
--- a/migrations/acs_metadata.sql
+++ b/migrations/acs_metadata.sql
@@ -1,7 +1,3 @@
-CREATE TEMP TABLE meta ( _json text , release_year text );
-INSERT INTO meta VALUES(:'CONTENT_CURR', :'YEAR_CURR');
-INSERT INTO meta VALUES(:'CONTENT_PREV', :'YEAR_PREV');
-
 CREATE SCHEMA IF NOT EXISTS acs;
 DROP TABLE IF EXISTS acs.metadata;
 CREATE TABLE acs.metadata (

--- a/migrations/decennial_metadata.sql
+++ b/migrations/decennial_metadata.sql
@@ -1,7 +1,3 @@
-CREATE TEMP TABLE meta ( _json text , release_year text );
-INSERT INTO meta VALUES(:'CONTENT_CURR', :'YEAR_CURR');
-INSERT INTO meta VALUES(:'CONTENT_PREV', :'YEAR_PREV');
-
 CREATE SCHEMA IF NOT EXISTS decennial;
 DROP TABLE IF EXISTS decennial.metadata;
 CREATE TABLE decennial.metadata (

--- a/migrations/metadata.sh
+++ b/migrations/metadata.sh
@@ -15,28 +15,36 @@ case $i in
 esac
 done
 
+function get_metadata() {
+    local year=$1
+    base_url="https://raw.githubusercontent.com/NYCPlanning/db-factfinder/dev/factfinder/data"
+    url="$base_url/$datasource/$year/metadata.json"
+    mkdir -p $(pwd)/.migration/metadata/$datasource/$year && (
+        cd $(pwd)/.migration/metadata/$datasource/$year
+        curl -O $url
+    )
+}
+
 if [ ! -z "$datasource" ] && [ ! -z "$year_curr" ] && [ ! -z "$year_prev" ]; then
     echo "loading metadata for $datasource year_curr: $year_curr year_prev: $year_prev"
-    base_url="https://raw.githubusercontent.com/NYCPlanning/db-factfinder/dev/factfinder/data"
-    url_curr="$base_url/$datasource/$year_curr/metadata.json"
-    url_prev="$base_url/$datasource/$year_prev/metadata.json"
-    CONTENT_CURR="$(curl -s $url_curr | jq -r 'del(.[].census_variable)')"
-    CONTENT_PREV="$(curl -s $url_prev | jq -r 'del(.[].census_variable)')"
+    (get_metadata $year_curr & get_metadata $year_prev wait && echo "done")
+    path_curr=$(pwd)/.migration/metadata/$datasource/$year_curr/metadata.json
+    path_prev=$(pwd)/.migration/metadata/$datasource/$year_prev/metadata.json
+
     if [ $datasource == "acs" ]; then
-        echo "$datasource"
-        psql $DATABASE_URL \
-            -v CONTENT_CURR="$CONTENT_CURR" \
-            -v CONTENT_PREV="$CONTENT_PREV" \
-            -v YEAR_CURR="$year_curr" \
-            -v YEAR_PREV="$year_prev" \
-            -f migrations/acs_metadata.sql
+        psql $DATABASE_URL -c "
+            CREATE TEMP TABLE meta ( _json text , release_year text );
+            INSERT INTO meta VALUES('$(cat $path_curr)', '$year_curr');
+            INSERT INTO meta VALUES('$(cat $path_prev)', '$year_prev');
+            $(cat migrations/acs_metadata.sql)
+        "
     else
-        psql $DATABASE_URL \
-            -v CONTENT_CURR="$CONTENT_CURR" \
-            -v CONTENT_PREV="$CONTENT_PREV" \
-            -v YEAR_CURR="$year_curr" \
-            -v YEAR_PREV="$year_prev" \
-            -f migrations/decennial_metadata.sql
+        psql $DATABASE_URL -c "
+            CREATE TEMP TABLE meta ( _json text , release_year text );
+            INSERT INTO meta VALUES('$(cat $path_curr)', '$year_curr');
+            INSERT INTO meta VALUES('$(cat $path_prev)', '$year_prev');
+            $(cat migrations/decennial_metadata.sql)
+        "
     fi
 else
     echo "incomplete information, please specify source, year_curr and year_prev"

--- a/migrations/metadata.sh
+++ b/migrations/metadata.sh
@@ -32,19 +32,25 @@ if [ ! -z "$datasource" ] && [ ! -z "$year_curr" ] && [ ! -z "$year_prev" ]; the
     path_prev=$(pwd)/.migration/metadata/$datasource/$year_prev/metadata.json
 
     if [ $datasource == "acs" ]; then
-        psql $DATABASE_URL -c "
+        path_sql=$(pwd)/.migration/metadata/acs/metadata.sql
+        echo "
             CREATE TEMP TABLE meta ( _json text , release_year text );
             INSERT INTO meta VALUES('$(cat $path_curr)', '$year_curr');
             INSERT INTO meta VALUES('$(cat $path_prev)', '$year_prev');
             $(cat migrations/acs_metadata.sql)
-        "
+        " > $path_sql
+        psql $DATABASE_URL -f $path_sql
+        rm $path_sql
     else
-        psql $DATABASE_URL -c "
+        path_sql=$(pwd)/.migration/metadata/decennial/metadata.sql
+        echo "
             CREATE TEMP TABLE meta ( _json text , release_year text );
             INSERT INTO meta VALUES('$(cat $path_curr)', '$year_curr');
             INSERT INTO meta VALUES('$(cat $path_prev)', '$year_prev');
             $(cat migrations/decennial_metadata.sql)
-        "
+        " > $path_sql
+        psql $DATABASE_URL -f $path_sql
+        rm $path_sql
     fi
 else
     echo "incomplete information, please specify source, year_curr and year_prev"


### PR DESCRIPTION
resolves the following error:
```console
{ Error: Command failed: ./migrations/cli.sh metadata --datasource=acs --year_curr=2019 --year_prev=2010
migrations/metadata.sh: line 27: /usr/bin/psql: Argument list too long

    at ChildProcess.exithandler (child_process.js:294:12)
    at ChildProcess.emit (events.js:198:13)
    at maybeClose (internal/child_process.js:982:16)
    at Process.ChildProcess._handle.onexit (internal/child_process.js:259:5)
  killed: false,
  code: 126,
  signal: null,
  cmd:
   './migrations/cli.sh metadata --datasource=acs --year_curr=2019 --year_prev=2010' }
migrations/metadata.sh: line 27: /usr/bin/psql: Argument list too long

loading metadata for acs year_curr: 2019 year_prev: 2010
acs
```