### PR TITLE
4738 Removing constraint from selection migration

### DIFF
--- a/migrations/selection.sql
+++ b/migrations/selection.sql
@@ -3,6 +3,6 @@ This will be used to store custom geography selections
 */
 CREATE TABLE IF NOT EXISTS selection (
 	geotype text CHECK(geotype IN ('blocks','tracts','ntas','cdtas','boroughs','districts')),
-	geoids text[] CHECK(array_length(geoids, 1) BETWEEN 2 AND 12),
+	geoids text[],
 	hash text PRIMARY KEY
 );


### PR DESCRIPTION
### Summary
This PR removes the constraint on the number of geos that can be in a selection

#### Tasks/Bug Numbers
 - Fixes [AB#4738](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/4738)
