### PR TITLE
Updating block summary level selection to use correct field for geoid

### DIFF
--- a/selection-helpers/summary-levels.js
+++ b/selection-helpers/summary-levels.js
@@ -5,9 +5,9 @@ const summaryLevels = {
       ct2020,
       borocode || ct2020 AS boroct2020,
       cb2020,
-      borocode,
+      borocode::text,
       bctcb2020,
-      geoid AS geoid,
+      bctcb2020 AS geoid,
       bctcb2020 as geolabel
     FROM pff_2020_census_blocks_21c
   `,


### PR DESCRIPTION
### Summary
This updates the selection helper for census blocks to use bctcb2020 for geoid instead of the actual geoid column
