### PR TITLE
remove + 1 for bin width (medianLocationMultiplier)

### DIFF
--- a/utils/median-of-ranges.js
+++ b/utils/median-of-ranges.js
@@ -33,7 +33,7 @@ function medianOfRanges(ranges) {
     (avg - medianRangeGroup.lower) / medianRange.quantity
   );
 
-  const medianLocationMultiplier = Math.abs(medianRange.bounds.upper - medianRange.bounds.lower) + 1;
+  const medianLocationMultiplier = Math.abs(medianRange.bounds.upper - medianRange.bounds.lower);
 
   const naturalMedian = medianRange.bounds.lower + (medianLocation * medianLocationMultiplier);
 


### PR DESCRIPTION
### Summary
Based on observation, everything is corrected calculated and assigned, except the `medianLocationMultiplier`. Since we reduce the order of the magnitude for the mdrms bins, the `+1` by the end will greatly change the outcome of the calculation. (vs before when bins are 1000 times bigger, the +1 impact is negligible)

Based on my understanding the median calculation, the `medianLocationMultiplier` corresponds to the width of the bin (upper - lower), so the +1 is not needed. we never noticed this issue because all the other medians have relatively large numbers, the difference the `+1` makes can be very small. 

refer to https://github.com/NYCPlanning/db-factfinder/wiki/Median-calculations#estimate-calculation
for more detailed explaination

#### Tasks/Bug Numbers
 - Fixes [AB#5340](https://dev.azure.com/NYCPlanning/ITD/_workitems/edit/5340)
