### PR TITLE
5419 Inflate previous year values before top bottom coding

### DIFF
--- a/utils/interpolate.js
+++ b/utils/interpolate.js
@@ -34,12 +34,8 @@ function interpolate(data, variable, year) {
 
   const naturalMedian = medianOfRanges(scenario);
 
-  const {
-    mutatedEstimate: trimmedEstimate,
-    codingThreshold,
-  } = topBottomCodeEstimate(naturalMedian, variable, year);
 
-  return { trimmedEstimate, codingThreshold };
+  return naturalMedian;
 }
 
 module.exports = interpolate;


### PR DESCRIPTION
### Summary
Previously top-bottom encoding was occurring at the end of interpolate. We remove it from interpolate, and instead top-bottom code for both single and aggregate geographies regardless of special variable type (median or not). 

We also move applyTransform above top-bottom encoding, to make sure previous year values are inflated before top bottom encoding. 

 - Fixes [AB#5419](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/5419)
