### PR TITLE
9773 Update Inflation Constant to 2020 Value

### DIFF
--- a/special-calculations/data/constants.js
+++ b/special-calculations/data/constants.js
@@ -1,5 +1,5 @@
 // constants for use in special calculations
-const INFLATION_FACTOR = 1.1751; // Updated to 2020 value
+const INFLATION_FACTOR = 1.1898; // Updated to 2020 value on 2022-07-20, previously was 1.1751
 const CORRELATION_COEFFICIENT_CONST = 1.645;
 const DIFF_PERCENT_THRESHOLD = -0.05;
 const DESIGN_FACTOR = 1.5;

--- a/special-calculations/data/constants.js
+++ b/special-calculations/data/constants.js
@@ -1,5 +1,5 @@
 // constants for use in special calculations
-const INFLATION_FACTOR = 1.1898; // Updated to 2020 value on 2022-07-20, previously was 1.1751
+const INFLATION_FACTOR = 1.1898;
 const CORRELATION_COEFFICIENT_CONST = 1.645;
 const DIFF_PERCENT_THRESHOLD = -0.05;
 const DESIGN_FACTOR = 1.5;


### PR DESCRIPTION
<!---
   The below template is a general guide, but not a strict prescription!
-->

### Summary
We need to update the inflation constant to the new value for 2020 data. The new inflation value is 1.1898.
This should be as simple as updating the "INFLATION_FACTOR" constant in the backend repo in `/special-calculations/data/constants.js` 
![image](https://user-images.githubusercontent.com/61206501/180058781-052ceb62-7a40-4b6a-aee6-f7cccfa05f1b.png)

This only effects data that represent a monetary value and numbers are only inflated for 2006-2010 data, so you need to make sure you select the ACS 2006-2010 data from the data source dropdown to test these changes:
Image. To test this, you may want to compare numbers for monetary data points as they show up in the app to the values in the database. Here are the variable IDs that get inflated (Note they are all lowercase in the front end app code and the database. Look at the column variable in the "2010" table under the "acs" schema in the db to look up values by these IDs. The number you see in the app for a given geography and variable should be equal to the same data point in the db times 1.1898 if you're changes are working as expected

o   MdHHInc

o   MnHHInc

o   MdFamInc

o   MdNFInc

o   PerCapInc

o   MdEWrk

o   MdEMFTWrk

o   MdEFFTWrk



#### Tasks/Bug Numbers
 - Completes [AB#9773](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/9773)


### Technical Explanation
I a changea da numba

### Any other info you think would help a reviewer understand this PR?
