### PR TITLE
9766 Update Pre and Post Inflation Top and Bottom Code Thresholds for 2006-2010 ACS Data

### DIFF
--- a/special-calculations/data/top-bottom-codings.js
+++ b/special-calculations/data/top-bottom-codings.js
@@ -55,7 +55,7 @@ const topBottomCodings = {
     mdhhinc: {
       upper: {
         preInflation: 200000,
-        postInflation: 235000,
+        postInflation: 238000,
       },
       lower: {
         preInflation: 9999,
@@ -65,7 +65,7 @@ const topBottomCodings = {
     mdfaminc: {
       upper: {
         preInflation: 200000,
-        postInflation: 235000,
+        postInflation: 238000,
       },
       lower: {
         preInflation: 9999,
@@ -75,7 +75,7 @@ const topBottomCodings = {
     mdnfinc: {
       upper: {
         preInflation: 200000,
-        postInflation: 235000,
+        postInflation: 238000,
       },
       lower: {
         preInflation: 9999,
@@ -85,31 +85,31 @@ const topBottomCodings = {
     mdewrk: {
       upper: {
         preInflation: 100000,
-        postInflation: 118000,
+        postInflation: 119000,
       },
       lower: {
         preInflation: 2499,
-        postInflation: 2900
+        postInflation: 3000
       }
     },
     mdemftwrk: {
       upper: {
         preInflation: 100000,
-        postInflation: 118000,
+        postInflation: 119000,
       },
       lower: {
         preInflation: 2499,
-        postInflation: 2900
+        postInflation: 3000
       }
     },
     mdefftwrk: {
       upper: {
         preInflation: 100000,
-        postInflation: 118000,
+        postInflation: 119000,
       },
       lower: {
         preInflation: 2499,
-        postInflation: 2900
+        postInflation: 3000
       }
     },
     mdrms: {
@@ -119,7 +119,7 @@ const topBottomCodings = {
     mdvl: {
       upper: {
         preInflation: 1000000,
-        postInflation: 1175000,
+        postInflation: 1190000,
       },
       lower: {
         preInflation: 0,
@@ -129,7 +129,7 @@ const topBottomCodings = {
     mdgr: {
       upper: {
         preInflation: 2000,
-        postInflation: 2350,
+        postInflation: 2400,
       },
       lower: {
         preInflation: 0,


### PR DESCRIPTION


<!---
   The below template is a general guide, but not a strict prescription!
-->

### Summary
For variables that have top and bottom code thresholds and also represent monetary values (such as median household income), we need to update the pre and post-inflation upper and lower thresholds in the code.

This should be as simple as updating some values in the file in the backend repo at labs-factfinder-api/special-calculations/data/top-bottom-codings.js. The object exported from that file has two top level properties: `[CUR_YEAR]` and `[PREV_YEAR]`. We don't need to change anything under the `[CUR_YEAR]` property because those values don't get inflated and the thresholds are the same for '16-'20 as they were for '15-'19. Here are the variable ids that need updated under `[PREV_YEAR]` and the new values (variable ids are all lowercased in the code):

*   MdHHInc:

  *  upper: preInflation: 200,000, postInflation: 238,000

  *  lower: preInflation: 9,999, postInflation: 12,000

*   MdFamInc:

  *  upper: preInflation: 200,000, postInflation: 238,000

  *  lower: preInflation: 9,999, postInflation: 12,000

*   MdNFInc:

  *  upper: preInflation: 200,000, postInflation: 238,000

  *  lower: preInflation: 9,999, postInflation: 12,000

*   MdEWrk:

  *  upper: preInflation: 100,000, postInflation: 119,000

  *  lower: preInflation: 2,499, postInflation: 3,000

*   MdEMFTWrk:

  *  upper: preInflation: 100,000, postInflation: 119,000

  *  lower: preInflation: 2,499, postInflation: 3,000

*   MdEFFTWrk:

  *  upper: preInflation: 100,000, postInflation: 119,000

  *  lower: preInflation: 2,499, postInflation: 3,000

*  MdVl:

 *  upper: preInflation: 1,000,000, postInflation: 1,190,000

 *  lower: none (leave as current value)

*  MdGR:

 *  upper: preInflation: 2,000, postInflation: 2,400

 *  lower: none (leave as current value) 

#### Tasks/Bug Numbers
 - Implements AB#9766


### Technical Explanation
I a changea da numba.  Some a bigga, some a smalla, some a no changea at all.

### Any other info you think would help a reviewer understand this PR?
