### PR TITLE
Temporarily revert "Consume Geosearch v2"

### DIFF
--- a/search-helpers/geosearch.js
+++ b/search-helpers/geosearch.js
@@ -1,7 +1,7 @@
 const rp = require('request-promise');
 
 const geosearch = (string) => {
-  const geoSearchAPI = `https://geosearch.planninglabs.nyc/v2/autocomplete?text=${string}`;
+  const geoSearchAPI = `https://geosearch.planninglabs.nyc/v1/autocomplete?text=${string}`;
 
   return rp(geoSearchAPI)
     .then(res => JSON.parse(res))
@@ -16,7 +16,7 @@ const geosearch = (string) => {
         type: 'address',
       };
     }))
-    .then(json => json.slice(0, 5));
+    .then(json => json.slice(0, 5)); // limit to first 5 results
 };
 
 module.exports = geosearch;


### PR DESCRIPTION
Reverts NYCPlanning/labs-factfinder-api#190

This is to release new PFF data before we complete QA of geosearch v2 in pff. 