### PR TITLE
5537 Add the population and housing facts to the map selection box

### DIFF
--- a/app.js
+++ b/app.js
@@ -34,6 +34,7 @@ app.use('/search', require('./routes/search'));
 app.use('/selection', require('./routes/selection'));
 app.use('/geo-options', require('./routes/geo-options'));
 app.use('/survey', require('./routes/survey'));
+app.use('/summary', require('./routes/summary'));
 
 app.use((req, res) => {
   res.status(404).json({

--- a/routes/summary.js
+++ b/routes/summary.js
@@ -1,0 +1,43 @@
+const express = require('express');
+const { DECENNIAL_LATEST_TABLE_FULL_PATH } = require('../special-calculations/data/constants');
+
+const router = express.Router();
+
+/*
+ * Helper function to calculate totals
+ * @param{Object} data - the data to calculate totals with
+ * @param{Object} variableNames - the variable names to calculate totals for
+ */
+function summarizeData(data, variableNames) {
+  var summarizedData = {};
+  variableNames.forEach((variableName) => { summarizedData[variableName] = 0; });
+  data.forEach((item) => { summarizedData[item.variable] += item.value });
+  return summarizedData;
+}
+
+/*
+ * Checks that the summary query parameter is a valid summary type
+ * @param{string} summary - The summary type
+ * @returns{Boolean}
+ */
+function isInvalidSummary(summary) {
+  const validSummaryNames = ['decennial', 'acs'];
+  if (validSummaryNames.includes(summary)) return false;
+  return true;
+}
+
+router.get('/:summary/:summaryvars/:geoids/', async (req, res) => {
+  const { app } = req;
+
+  const { summary, summaryvars, geoids: _geoids } = req.params;
+
+  const varString = "'" + summaryvars.split(',').join("','") + "'";
+  const idString = "'" + _geoids.split(',').join("','") + "'";
+
+  if (isInvalidSummary(summary)) res.status(400).send({ error: 'Invalid summary name. Summary must be acs or decennial' });
+  const summaryData = await app.db.query(`SELECT * FROM ${DECENNIAL_LATEST_TABLE_FULL_PATH} WHERE "geoid" IN (${idString}) and "variable" IN (${varString})`);
+  const totals = summarizeData(summaryData, summaryvars.split(','));
+  return res.send({ totals: totals, summaryData: summaryData });
+});
+
+module.exports = router;


### PR DESCRIPTION
<!---
   The below template is a general guide, but not a strict prescription!
-->

### Summary
Adds an API route used to provide summary totals to the map selection box.
<img width="357" alt="image" src="https://user-images.githubusercontent.com/61206501/181641594-8e05545d-f09c-4d6f-bd3c-fa988cc09f24.png">


#### Tasks/Bug Numbers
 - Along with a corresponding [pr in labs-factfinder](https://github.com/NYCPlanning/labs-factfinder/pull/1025), completes [AB#5537](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/5537)


