### PR TITLE
10016 - Prevent null value MOEs from being coalesced to 0

### DIFF
--- a/bin/www
+++ b/bin/www
@@ -65,7 +65,7 @@ function onListening() {
     ? `pipe ${addr}`
     : `port ${addr.port}`;
   debug(`Listening on ${bind}`);
-  console.log(`NYC Factfinder API running on port ${bind}`);
+  console.log(`NYC Factfinder API running on ${bind}`);
 }
 
 

--- a/query-helpers/acs.js
+++ b/query-helpers/acs.js
@@ -109,7 +109,6 @@ const acsSQL = (ids, isPrevious = false) => `
       --- margin_of_error (do not recalculate for non-aggregate selections)---
       --- coalesce null m to 0 ---
       CASE
-        WHEN SUM(margin_of_error) IS NULL THEN 0
         WHEN NOT ${isAggregate(ids)} THEN MAX(margin_of_error)
         ELSE SQRT(SUM(POWER(margin_of_error, 2)))
       END AS "marginOfError",

--- a/utils/data-processor.js
+++ b/utils/data-processor.js
@@ -94,7 +94,7 @@ class DataProcessor {
     // topBottomCodeEstimate() for aggregate selections
     if (config.specialType === 'median') {
       if (this.isAggregate) {
-        row.sum =  interpolate(this.data, row.variable, year);
+        row.sum = interpolate(this.data, row.variable, year);
       }
 
       const { sum, variable } = row;
@@ -131,7 +131,6 @@ class DataProcessor {
    */
   recalculateMarginOfError(row, year, config, wasCoded) {
     // MOE should not be calculated for top- or bottom-coded values
-
     if (wasCoded) {
       row.marginOfError = null;
     } else if (config.specialType === 'median') {
@@ -175,6 +174,7 @@ class DataProcessor {
    */
   recalculateIsReliable(row, wasCoded) {
     // top- or bottom-coded values are not reliable
+    if (!row.correlationCoefficient) return;
     row.isReliable = wasCoded ? false : executeFormula(this.data, row.variable, 'isReliable');
   }
 }

--- a/utils/data-processor.js
+++ b/utils/data-processor.js
@@ -174,7 +174,6 @@ class DataProcessor {
    */
   recalculateIsReliable(row, wasCoded) {
     // top- or bottom-coded values are not reliable
-    if (!row.correlationCoefficient) return;
     row.isReliable = wasCoded ? false : executeFormula(this.data, row.variable, 'isReliable');
   }
 }


### PR DESCRIPTION
### Summary
This PR attempts to address AB[#10016](https://dev.azure.com/NYCPlanning/ITD/_sprints/taskboard/Open%20Source%20Engineering/ITD/2022/Q3/Sprint%20R?workitem=10016). The main issue is a line of SQL in [acs.js](https://github.com/NYCPlanning/labs-factfinder-api/blob/c2690b69f0b0c65c732d28dbd10ae2000db5d2dd/query-helpers/acs.js#L112) which coalesces any null MOE values to 0. However, without this line some other MOEs are not calculated – particularly those in the difference table rows.

~~A similar issue with null values was occurring with the coefficient of correlation. When we recalculate the reliability of a given row, we execute the isReliable formula with FormulaParser. The [formula](https://github.com/NYCPlanning/labs-factfinder-api/blob/c2690b69f0b0c65c732d28dbd10ae2000db5d2dd/utils/formulas.js#L36) checks if the cv is under 20 and if it is, returns true. However, if that cv is null (as in the case of [AB#10016](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/10016)), this will always return true, so I added a simple check to see if there is a cv before recalculating.~~

Before:
![Screen Shot 2022-08-25 at 10 37 43 AM](https://user-images.githubusercontent.com/43344288/186697784-78e43556-a6dc-4f8f-9e08-a2a2f270cbf2.png)

After:
![Screen Shot 2022-08-25 at 10 38 18 AM](https://user-images.githubusercontent.com/43344288/186697825-7a4ee5b0-ba37-4fa4-8b71-419018a888e1.png)


#### Tasks/Bug Numbers
 - Fixes AB[#10016](https://dev.azure.com/NYCPlanning/ITD/_sprints/taskboard/Open%20Source%20Engineering/ITD/2022/Q3/Sprint%20R?workitem=10016)