### PR TITLE
Check that row cv is not null before recalculating reliability

### DIFF
--- a/utils/data-processor.js
+++ b/utils/data-processor.js
@@ -175,6 +175,7 @@ class DataProcessor {
    */
   recalculateIsReliable(row, wasCoded) {
     // top- or bottom-coded values are not reliable
+    if (!row.correlationCoefficient) return;
     row.isReliable = wasCoded ? false : executeFormula(this.data, row.variable, 'isReliable');
   }
 }


### PR DESCRIPTION
When recalculating the reliability of a given row, we execute the isReliable formula with FormulaParser. The [formula](https://github.com/NYCPlanning/labs-factfinder-api/blob/c2690b69f0b0c65c732d28dbd10ae2000db5d2dd/utils/formulas.js#L36) checks if the cv is under 20 and if it is, returns true. However, if that cv is null (as in the case of [AB#10016](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/10016)), this will incorrectly return true. So I added this simple check to see if there is a cv before recalculating.