### PR TITLE
Switching back to geosearch v2 url

### DIFF
--- a/search-helpers/geosearch.js
+++ b/search-helpers/geosearch.js
@@ -1,7 +1,7 @@
 const rp = require('request-promise');
 
 const geosearch = (string) => {
-  const geoSearchAPI = `https://geosearch.planninglabs.nyc/v1/autocomplete?text=${string}`;
+  const geoSearchAPI = `https://geosearch.planninglabs.nyc/v2/autocomplete?text=${string}`;
 
   return rp(geoSearchAPI)
     .then(res => JSON.parse(res))
@@ -16,7 +16,7 @@ const geosearch = (string) => {
         type: 'address',
       };
     }))
-    .then(json => json.slice(0, 5)); // limit to first 5 results
+    .then(json => json.slice(0, 5));
 };
 
 module.exports = geosearch;


### PR DESCRIPTION
### Summary
This PR switches the geosearch helper over to use the Geosearch v2 URL. This PR is against `staging` because we have [some changes](https://github.com/NYCPlanning/labs-factfinder-api/pull/204) in `develop` that are still awaiting QA.
