### PR TITLE
Add localhost with default FE port to CORS policy

### DIFF
--- a/app.js
+++ b/app.js
@@ -19,7 +19,7 @@ app.db = pgp(process.env.DATABASE_URL);
 
 // allows CORS
 app.use(cors({
-  origin: ['https://staging--labs-factfinder.netlify.app','https://develop--labs-factfinder.netlify.app','https://popfactfinder.planning.nyc.gov'],
+  origin: ['https://staging--labs-factfinder.netlify.app','https://develop--labs-factfinder.netlify.app','https://popfactfinder.planning.nyc.gov', 'http://localhost:4200'],
   methods: "GET,HEAD,PUT,PATCH,POST,DELETE",
   allowedHeaders: 'X-Requested-With,Content-Type,Authorization',
 }))


### PR DESCRIPTION
### Summary
Currently we cannot reach https://factfinder-api-develop.herokuapp.com from local environments due to the existing CORS policy defined in `app.js`. This PR adds `http://localhost:4200` to that policy so that we can reach it from the default port defined when running `npm run start` over in the PFF front end repo.
