### PR TITLE
11704 update API to process large geo selections (typically census tracks or blocks) as POST requests

### DIFF
--- a/routes/selection.js
+++ b/routes/selection.js
@@ -83,7 +83,7 @@ router.post('/:geotype', async (req, res) => {
     try {
       const selection =  await app.db.query('SELECT * FROM selection WHERE hash = ${geoid}', { geoid });
 
-      if (selection?.length > 0) {
+      if (selection && selection.length > 0) {
         const {
           geotype: selectionGeotype,
           geoids: selectionGeoids

--- a/routes/selection.js
+++ b/routes/selection.js
@@ -83,7 +83,7 @@ router.post('/:geotype', async (req, res) => {
     try {
       const selection =  await app.db.query('SELECT * FROM selection WHERE hash = ${geoid}', { geoid });
 
-      if (selection && selection.length > 0) {
+      if (selection?.length > 0) {
         const {
           geotype: selectionGeotype,
           geoids: selectionGeoids
@@ -99,7 +99,8 @@ router.post('/:geotype', async (req, res) => {
             });
           })
           .catch((err) => {
-            console.log('err', err); // eslint-disable-line
+            /* eslint-disable-next-line no-console */
+            console.log('err', err);
           });
       } else {
         res.status(404).send({
@@ -122,7 +123,8 @@ router.post('/:geotype', async (req, res) => {
         });
       })
       .catch((err) => {
-        console.log('err', err); // eslint-disable-line
+        /* eslint-disable-next-line  no-console */
+        console.log('err', err);
       });
   }
 });

--- a/routes/summary.js
+++ b/routes/summary.js
@@ -54,9 +54,6 @@ router.post('/:summary/:summaryvars', async (req, res) => {
   const geoids = req.body;
   const { summary, summaryvars } = req.params;
 
-  console.log('reqreqreq', req);
-  console.log("geoids", geoids, typeof(geoids));
-
   const varString = "'" + summaryvars.split(',').join("','") + "'";
   const idString = "'" + geoids.join("','") + "'";
 


### PR DESCRIPTION
### Summary
First hack at this bug:
 Selecting large amounts of census tracks or blocks causes the api to return a `ERR_FAILED 414 (Request-URI Too Long)` error. 

Updated the API to accept geo selections as POST requests
 - moved the geoid from the request URL to the body of the request avoiding the 414 error


#### Tasks/Bug Numbers
 - Fixes [AB#11704](https://dev.azure.com/NYCPlanning/ITD/_workitems/edit/11704)

