### PR TITLE
12685 updated thresholds for top and bottom variables

### DIFF
--- a/special-calculations/data/top-bottom-codings.js
+++ b/special-calculations/data/top-bottom-codings.js
@@ -40,7 +40,7 @@ const topBottomCodings = {
     },
     mdvl: {
       upper: 2000000,
-      lower: 0,
+      lower: 10000,
     },
     mdgr: {
       upper: 3500,
@@ -55,61 +55,61 @@ const topBottomCodings = {
     mdhhinc: {
       upper: {
         preInflation: 200000,
-        postInflation: 238000,
+        postInflation: 250000,
       },
       lower: {
         preInflation: 9999,
-        postInflation: 12000
+        postInflation: 12500
       }
     },
     mdfaminc: {
       upper: {
         preInflation: 200000,
-        postInflation: 238000,
+        postInflation: 250000,
       },
       lower: {
         preInflation: 9999,
-        postInflation: 12000
+        postInflation: 12500
       }
     },
     mdnfinc: {
       upper: {
         preInflation: 200000,
-        postInflation: 238000,
+        postInflation: 250000,
       },
       lower: {
         preInflation: 9999,
-        postInflation: 12000
+        postInflation: 12500
       }
     },
     mdewrk: {
       upper: {
         preInflation: 100000,
-        postInflation: 119000,
+        postInflation: 125000,
       },
       lower: {
         preInflation: 2499,
-        postInflation: 3000
+        postInflation: 3100
       }
     },
     mdemftwrk: {
       upper: {
         preInflation: 100000,
-        postInflation: 119000,
+        postInflation: 125000,
       },
       lower: {
         preInflation: 2499,
-        postInflation: 3000
+        postInflation: 3100
       }
     },
     mdefftwrk: {
       upper: {
         preInflation: 100000,
-        postInflation: 119000,
+        postInflation: 125000,
       },
       lower: {
         preInflation: 2499,
-        postInflation: 3000
+        postInflation: 3100
       }
     },
     mdrms: {
@@ -119,7 +119,7 @@ const topBottomCodings = {
     mdvl: {
       upper: {
         preInflation: 1000000,
-        postInflation: 1190000,
+        postInflation: 1254000,
       },
       lower: {
         preInflation: 0,
@@ -129,7 +129,7 @@ const topBottomCodings = {
     mdgr: {
       upper: {
         preInflation: 2000,
-        postInflation: 2400,
+        postInflation: 2500,
       },
       lower: {
         preInflation: 0,


### PR DESCRIPTION
<!---
   The below template is a general guide, but not a strict prescription!
-->

### Summary
*UPDATED THRESHOLDS FOR TOP/BOTTOM VARIABLES*

2017-2021
Housing –
Top- and bottom-coding changes:
MdVl:
Top: no changes
Bottom: median calculation: 10,000, shown as: 10,000-
 
2006-2010
Economic – 
Top- and bottom-coding changes:
MdHHInc:
Top: median calculation: 200,000, inflated/shown as: 250,000+
Bottom: median calculation: 9,999, inflated/shown as: 12,500-
MdFamInc:
Top: median calculation: 200,000, inflated/shown as: 250,000+
Bottom: median calculation: 9,999, inflated/shown as: 12,500-
MdNFInc:
Top: median calculation: 200,000, inflated/shown as: 250,000+
Bottom: median calculation: 9,999, inflated/shown as: 12,500-
MdEWrk:
Top: median calculation: 100,000, inflated/shown as: 125,000+
Bottom: median calculation: 2,499, inflated/shown as: 3,100-
MdEMFTWrk:
Top: median calculation: 100,000, inflated/shown as: 125,000+
Bottom: median calculation: 2,499, inflated/shown as: 3,100-
MdEFFTWrk:
Top: median calculation: 100,000, inflated/shown as: 125,000+
Bottom: median calculation: 2,499, inflated/shown as: 3,100-

Housing – 
Top- and bottom-coding changes:
MdVl:
Top: median calculation: 1,000,000, inflated/shown as: 1,254,000+
Bottom: no bottom coding
MdGR:
Top: median calculation: 2,000, inflated/shown as: 2,500+
Bottom: no bottom coding


#### Tasks/Bug Numbers
 - Fixes [AB#12685](https://dev.azure.com/NYCPlanning/ITD/_workitems/edit/12685)
<!---
Provide a link to a ticket, if applicable

