### PR TITLE
Switch download path for metadata back to main branch of the repo

### DIFF
--- a/migrations/metadata.sh
+++ b/migrations/metadata.sh
@@ -17,7 +17,7 @@ done
 
 if [ ! -z "$datasource" ] && [ ! -z "$year_curr" ] && [ ! -z "$year_prev" ]; then
     echo "loading metadata for $datasource year_curr: $year_curr year_prev: $year_prev"
-    base_url="https://raw.githubusercontent.com/NYCPlanning/db-factfinder/dev/factfinder/data"
+    base_url="https://raw.githubusercontent.com/NYCPlanning/db-factfinder/main/factfinder/data"
     url_curr="$base_url/$datasource/$year_curr/metadata.json"
     url_prev="$base_url/$datasource/$year_prev/metadata.json"
     base_path="$( cd ../"$(dirname "$0")" ; pwd -P )"


### PR DESCRIPTION
### Summary
This PR updates `metadata.sh` to point to the main branch of [db-factfinder](https://github.com/NYCPlanning/db-factfinder) when downloading the raw metadata files. We used a `dev` branch when doing the 2016-2020 update but we're back to using `main` now.