### PR TITLE
Add planninglabs.nyc domains to CORS

### DIFF
--- a/app.js
+++ b/app.js
@@ -19,7 +19,7 @@ app.db = pgp(process.env.DATABASE_URL);
 
 // allows CORS
 app.use(cors({
-  origin: ['https://staging--labs-factfinder.netlify.app','https://develop--labs-factfinder.netlify.app','https://popfactfinder.planning.nyc.gov', 'http://localhost:4200'],
+  origin: ['https://staging--labs-factfinder.netlify.app','https://develop--labs-factfinder.netlify.app','https://popfactfinder.planning.nyc.gov', 'http://localhost:4200','https://factfinder-staging.planninglabs.nyc','https://factfinder-develop.planninglabs.nyc'],
   methods: "GET,HEAD,PUT,PATCH,POST,DELETE",
   allowedHeaders: 'X-Requested-With,Content-Type,Authorization',
 }))


### PR DESCRIPTION
This PR updates the CORS policy to including planninglabs.nyc domains for staging and develop.