### PR TITLE
issue 303 get coded rows to set isReliable to false when top/bottom coded

### DIFF
--- a/utils/data-processor.js
+++ b/utils/data-processor.js
@@ -174,7 +174,7 @@ class DataProcessor {
    */
   recalculateIsReliable(row, wasCoded) {
     // top- or bottom-coded values are not reliable
-    if (!row.correlationCoefficient) return;
+    if (!row.correlationCoefficient && !wasCoded) return;
     row.isReliable = wasCoded ? false : executeFormula(this.data, row.variable, 'isReliable');
   }
 }


### PR DESCRIPTION
### Summary
top and bottom coded values should be grey. This fix keeps another [bug fix](https://github.com/NYCPlanning/labs-factfinder-api/pull/204) intact while properly set `isCoded` which in turn sets `isReliable` to false when value is top or bottom coded.


#### Tasks/Bug Numbers
 - Closes #303 